### PR TITLE
Biometrics are added as double auth to change profile data

### DIFF
--- a/src/components/organisms/ProfileEditForm.tsx
+++ b/src/components/organisms/ProfileEditForm.tsx
@@ -1,17 +1,21 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import Theme from 'theme';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
 import { Container } from 'components';
+import { useTranslation } from 'react-i18next';
+import ReactNativeBiometrics from 'react-native-biometrics';
 import { ButtonFieldEdit } from './ButtonFieldEdit';
 
 interface Props {
   onSubmit: () => void;
 }
 
+const rnBiometrics = new ReactNativeBiometrics({ allowDeviceCredentials: true });
+
 const ProfileEditForm: React.FC<Props> = () => {
   const { navigate } = useNavigation<NativeStackNavigationProp<any>>();
-
+  const { t } = useTranslation();
   const fields = [
     {
       label: 'Alias',
@@ -35,10 +39,21 @@ const ProfileEditForm: React.FC<Props> = () => {
     },
   ];
 
+  const biometricManager = useCallback(async (field: any) => {
+    const result = await rnBiometrics.simplePrompt({ promptMessage: t('global:confirmYourIdentity') });
+    if (result.success) {
+      navigate('EditProfileField', { field });
+    }
+  }, [navigate, t]);
+
   const handlerShowForm = (field: any) => {
+    if (field.type === 'email' || field.type === 'phone') {
+      biometricManager(field);
+    }
     if (field.type === 'address') {
       navigate('EditAddress');
-    } else {
+    }
+    if (field.type === 'alias') {
       navigate('EditProfileField', { field });
     }
   };


### PR DESCRIPTION
# Description

-Biometrics are added as double auth to change profile data

Platform
- [x] iOS
- [ ] Android

Device
- [ ] Real device
- [x] Emulator

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

![Simulator Screen Recording - iPhone 15 Pro Max - 2023-10-17 at 12 59 36](https://github.com/NeuronMexico/Ethos-app/assets/51216464/d3e291bc-5797-4c0d-993f-91cf224f03ef)

